### PR TITLE
Add unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch:
 
 jobs:
   build:
@@ -40,6 +39,3 @@ jobs:
       - name: Lint
         run: npm run lint
         continue-on-error: true
-
-      - name: Test
-        run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Test
+        run: npm run test
+
       - name: Lint
         run: npm run lint
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -39,3 +40,6 @@ jobs:
       - name: Lint
         run: npm run lint
         continue-on-error: true
+
+      - name: Test
+        run: npm run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ npm run build
 # Run linting
 npm run lint
 
+# Run tests
+npm run test
+
 # Clean dist directories
 npm run clean
 
@@ -84,6 +87,24 @@ npm run cli -- rebuild-index
 - `otel-otlp-http` - OTLP HTTP exporter
 
 **Presets**: quick (10s), standard (30s), stress (60s), sustained (300s)
+
+## Testing
+
+Unit tests use Vitest. Tests are colocated with source files (`*.test.ts`).
+
+```bash
+# Run all tests
+npm run test
+
+# Run tests for a specific package
+cd packages/results-store && npm test
+cd packages/cli && npm test
+```
+
+**Tested modules**:
+- `packages/results-store/src/comparison.ts` - `compareResults()`, `calculateDiff()`, formatting utilities
+- `packages/results-store/src/storage.ts` - `ResultsStorage` class (save, load, delete, rebuildIndex)
+- `packages/cli/src/utils.ts` - `parseArgs()`, `expandPath()`, `formatDuration()`
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,37 @@ npm run clean
 # Run linting
 npm run lint
 
+# Run tests
+npm run test
+
 # Run CLI in development
 node packages/cli/dist/index.js run --help
 ```
+
+## Testing
+
+The project uses [Vitest](https://vitest.dev/) for unit testing. Tests are located alongside source files with `.test.ts` extensions.
+
+### Running Tests
+
+```bash
+# Run all tests
+npm run test
+
+# Run tests for a specific package
+cd packages/results-store && npm test
+cd packages/cli && npm test
+```
+
+### Test Coverage
+
+Tests cover core functionality:
+
+- **results-store**: Storage operations (save, load, delete, rebuild index), comparison calculations (`calculateDiff`), formatting utilities
+- **cli**: Argument parsing, path expansion, duration formatting
+
+### Adding Tests
+
+1. Create test files alongside source files with `.test.ts` extension
+2. Import from `vitest` (`describe`, `it`, `expect`, etc.)
+3. Run tests with `npm run test`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "turbo": "^2.0.0",
-        "typescript": "~5.3.0"
+        "typescript": "~5.3.0",
+        "vitest": "^2.0.0"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -101,6 +102,397 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.6.0.tgz",
@@ -168,6 +560,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
@@ -1061,6 +1460,356 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/autocannon": {
       "version": "7.12.7",
       "resolved": "https://registry.npmjs.org/@types/autocannon/-/autocannon-7.12.7.tgz",
@@ -1091,6 +1840,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -1202,6 +1958,119 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -1326,6 +2195,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1485,6 +2364,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1514,6 +2403,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -1531,6 +2437,16 @@
       "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
       "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
       "license": "ISC"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
@@ -1709,6 +2625,16 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1796,6 +2722,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1823,6 +2756,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1839,6 +2811,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1846,6 +2828,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -2073,6 +3065,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2470,6 +3477,23 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/manage-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/manage-path/-/manage-path-2.0.0.tgz",
@@ -2578,6 +3602,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -2728,6 +3771,30 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pino": {
       "version": "9.14.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
@@ -2780,6 +3847,35 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
@@ -3033,6 +4129,51 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.55.1",
+        "@rollup/rollup-android-arm64": "4.55.1",
+        "@rollup/rollup-darwin-arm64": "4.55.1",
+        "@rollup/rollup-darwin-x64": "4.55.1",
+        "@rollup/rollup-freebsd-arm64": "4.55.1",
+        "@rollup/rollup-freebsd-x64": "4.55.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+        "@rollup/rollup-linux-arm64-musl": "4.55.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+        "@rollup/rollup-linux-loong64-musl": "4.55.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-musl": "4.55.1",
+        "@rollup/rollup-openbsd-x64": "4.55.1",
+        "@rollup/rollup-openharmony-arm64": "4.55.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+        "@rollup/rollup-win32-x64-gnu": "4.55.1",
+        "@rollup/rollup-win32-x64-msvc": "4.55.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3231,6 +4372,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3252,6 +4400,16 @@
         "atomic-sleep": "^1.0.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -3261,6 +4419,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3269,6 +4434,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -3373,6 +4545,50 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toad-cache": {
@@ -3579,6 +4795,222 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "turbo": "^2.0.0",
-    "typescript": "~5.3.0"
+    "typescript": "~5.3.0",
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run src/*.test.ts"
   },
   "dependencies": {
     "@otel-perf/benchmark-runner": "*",

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import os from 'os';
+import path from 'path';
+import { parseArgs, getDefaultOtelPath, formatDuration, expandPath } from './utils.js';
+
+describe('parseArgs', () => {
+  describe('basic parsing', () => {
+    it('should parse flag with value', () => {
+      const result = parseArgs(['--name', 'value']);
+      expect(result.name).toBe('value');
+    });
+
+    it('should parse multiple flags with values', () => {
+      const result = parseArgs(['--app', 'express', '--scenario', 'simple-json']);
+      expect(result.app).toBe('express');
+      expect(result.scenario).toBe('simple-json');
+    });
+
+    it('should parse boolean flag without value', () => {
+      const result = parseArgs(['--verbose']);
+      expect(result.verbose).toBe(true);
+    });
+
+    it('should parse mixed flags and boolean flags', () => {
+      const result = parseArgs(['--app', 'express', '--verbose', '--mode', 'baseline']);
+      expect(result.app).toBe('express');
+      expect(result.verbose).toBe(true);
+      expect(result.mode).toBe('baseline');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return empty object for empty args', () => {
+      const result = parseArgs([]);
+      expect(result).toEqual({});
+    });
+
+    it('should ignore non-flag arguments', () => {
+      const result = parseArgs(['command', '--flag', 'value', 'extra']);
+      expect(result.flag).toBe('value');
+      expect(result.command).toBeUndefined();
+    });
+
+    it('should handle flag at end as boolean', () => {
+      const result = parseArgs(['--app', 'express', '--save']);
+      expect(result.app).toBe('express');
+      expect(result.save).toBe(true);
+    });
+
+    it('should handle consecutive boolean flags', () => {
+      const result = parseArgs(['--verbose', '--debug', '--save']);
+      expect(result.verbose).toBe(true);
+      expect(result.debug).toBe(true);
+      expect(result.save).toBe(true);
+    });
+
+    it('should handle values that look like flags but are quoted', () => {
+      // When a value starts with -- but is not a flag position, it should be treated as a value
+      const result = parseArgs(['--message', '--not-a-flag']);
+      // Based on the implementation, this will be treated as message=true, not-a-flag=true
+      expect(result.message).toBe(true);
+      expect(result['not-a-flag']).toBe(true);
+    });
+  });
+
+  describe('real-world scenarios', () => {
+    it('should parse run command args', () => {
+      const result = parseArgs([
+        '--app',
+        'express',
+        '--scenario',
+        'simple-json',
+        '--mode',
+        'baseline',
+        '--preset',
+        'quick',
+        '--label',
+        'test-run',
+        '--save',
+      ]);
+
+      expect(result.app).toBe('express');
+      expect(result.scenario).toBe('simple-json');
+      expect(result.mode).toBe('baseline');
+      expect(result.preset).toBe('quick');
+      expect(result.label).toBe('test-run');
+      expect(result.save).toBe(true);
+    });
+
+    it('should parse compare command args', () => {
+      const result = parseArgs([
+        '--baseline',
+        'baseline-label',
+        '--target',
+        'target-label',
+        '--format',
+        'markdown',
+      ]);
+
+      expect(result.baseline).toBe('baseline-label');
+      expect(result.target).toBe('target-label');
+      expect(result.format).toBe('markdown');
+    });
+  });
+});
+
+describe('getDefaultOtelPath', () => {
+  it('should return path in home directory', () => {
+    const result = getDefaultOtelPath();
+    const expected = path.join(os.homedir(), 'workspace', 'opentelemetry-js');
+    expect(result).toBe(expected);
+  });
+});
+
+describe('formatDuration', () => {
+  describe('milliseconds', () => {
+    it('should format sub-second durations in ms', () => {
+      expect(formatDuration(500)).toBe('500ms');
+    });
+
+    it('should format exactly 999ms', () => {
+      expect(formatDuration(999)).toBe('999ms');
+    });
+  });
+
+  describe('seconds', () => {
+    it('should format 1 second', () => {
+      expect(formatDuration(1000)).toBe('1.0s');
+    });
+
+    it('should format seconds with decimal', () => {
+      expect(formatDuration(1500)).toBe('1.5s');
+    });
+
+    it('should format 59 seconds', () => {
+      expect(formatDuration(59000)).toBe('59.0s');
+    });
+  });
+
+  describe('minutes', () => {
+    it('should format exactly 1 minute', () => {
+      expect(formatDuration(60000)).toBe('1m 0s');
+    });
+
+    it('should format minutes and seconds', () => {
+      expect(formatDuration(90000)).toBe('1m 30s');
+    });
+
+    it('should format multiple minutes', () => {
+      expect(formatDuration(300000)).toBe('5m 0s');
+    });
+
+    it('should format 5 minutes 30 seconds', () => {
+      expect(formatDuration(330000)).toBe('5m 30s');
+    });
+  });
+});
+
+describe('expandPath', () => {
+  it('should expand tilde to home directory', () => {
+    const result = expandPath('~/workspace');
+    expect(result).toBe(path.join(os.homedir(), 'workspace'));
+  });
+
+  it('should expand tilde with nested path', () => {
+    const result = expandPath('~/workspace/opentelemetry-js');
+    expect(result).toBe(path.join(os.homedir(), 'workspace', 'opentelemetry-js'));
+  });
+
+  it('should resolve relative paths', () => {
+    const result = expandPath('./test');
+    expect(result).toBe(path.resolve('./test'));
+  });
+
+  it('should preserve absolute paths', () => {
+    const result = expandPath('/usr/local/bin');
+    expect(result).toBe('/usr/local/bin');
+  });
+
+  it('should handle path without tilde', () => {
+    const result = expandPath('relative/path');
+    expect(result).toBe(path.resolve('relative/path'));
+  });
+});

--- a/packages/results-store/package.json
+++ b/packages/results-store/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run src/*.test.ts"
   },
   "dependencies": {
     "uuid": "^9.0.0"

--- a/packages/results-store/src/comparison.test.ts
+++ b/packages/results-store/src/comparison.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect } from 'vitest';
+import {
+  compareResults,
+  formatPercentage,
+  formatLatency,
+  formatNumber,
+  formatBytes,
+} from './comparison.js';
+import type { StoredBenchmark } from './schema.js';
+
+// Helper to create a minimal StoredBenchmark for testing
+function createBenchmark(overrides: {
+  requestsPerSecond?: number;
+  latencyP50?: number;
+  latencyP99?: number;
+  throughput?: number;
+  errors?: number;
+}): StoredBenchmark {
+  return {
+    metadata: {
+      id: 'test-id',
+      label: 'test-label',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      git: {
+        branch: 'main',
+        commit: 'abc123',
+        shortCommit: 'abc123',
+        commitMessage: 'test',
+        commitDate: '2024-01-01',
+      },
+      environment: {
+        nodeVersion: 'v20.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        cpuModel: 'test',
+        cpuCores: 4,
+        totalMemory: 16000000000,
+      },
+      config: {
+        app: 'express',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      },
+    },
+    results: {
+      autocannon: {
+        requestsPerSecond: {
+          mean: overrides.requestsPerSecond ?? 1000,
+          stddev: 50,
+          min: 900,
+          max: 1100,
+          p50: 1000,
+          p90: 1050,
+          p99: 1080,
+        },
+        latency: {
+          mean: 10,
+          stddev: 2,
+          min: 5,
+          max: 20,
+          p50: overrides.latencyP50 ?? 10,
+          p90: 15,
+          p99: overrides.latencyP99 ?? 18,
+        },
+        throughput: {
+          mean: overrides.throughput ?? 1000000,
+          stddev: 50000,
+          min: 900000,
+          max: 1100000,
+        },
+        totalRequests: 30000,
+        errors: overrides.errors ?? 0,
+        timeouts: 0,
+      },
+    },
+  };
+}
+
+describe('compareResults', () => {
+  describe('calculateDiff behavior (via compareResults)', () => {
+    it('should calculate positive percentage change correctly', () => {
+      const baseline = createBenchmark({ requestsPerSecond: 1000 });
+      const target = createBenchmark({ requestsPerSecond: 1100 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.diff.requestsPerSecond.absolute).toBe(100);
+      expect(result.diff.requestsPerSecond.percentage).toBeCloseTo(10, 1);
+      expect(result.diff.requestsPerSecond.improved).toBe(true);
+    });
+
+    it('should calculate negative percentage change correctly', () => {
+      const baseline = createBenchmark({ requestsPerSecond: 1000 });
+      const target = createBenchmark({ requestsPerSecond: 900 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.diff.requestsPerSecond.absolute).toBe(-100);
+      expect(result.diff.requestsPerSecond.percentage).toBeCloseTo(-10, 1);
+      expect(result.diff.requestsPerSecond.improved).toBe(false);
+    });
+
+    it('should handle zero baseline (division by zero)', () => {
+      const baseline = createBenchmark({ requestsPerSecond: 0 });
+      const target = createBenchmark({ requestsPerSecond: 100 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.diff.requestsPerSecond.percentage).toBe(0);
+      expect(result.diff.requestsPerSecond.absolute).toBe(100);
+    });
+
+    it('should handle latency correctly (lower is better)', () => {
+      const baseline = createBenchmark({ latencyP50: 20 });
+      const target = createBenchmark({ latencyP50: 15 });
+
+      const result = compareResults(baseline, target);
+
+      // Lower latency is better, so this should be an improvement
+      expect(result.diff.latencyP50.improved).toBe(true);
+      expect(result.diff.latencyP50.absolute).toBe(-5);
+      expect(result.diff.latencyP50.percentage).toBeCloseTo(-25, 1);
+    });
+
+    it('should handle latency regression (higher is worse)', () => {
+      const baseline = createBenchmark({ latencyP50: 10 });
+      const target = createBenchmark({ latencyP50: 15 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.diff.latencyP50.improved).toBe(false);
+      expect(result.diff.latencyP50.absolute).toBe(5);
+      expect(result.diff.latencyP50.percentage).toBeCloseTo(50, 1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should track increased errors as regression', () => {
+      const baseline = createBenchmark({ errors: 0 });
+      const target = createBenchmark({ errors: 5 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.diff.errors.absolute).toBe(5);
+      expect(result.diff.errors.improved).toBe(false);
+    });
+
+    it('should track decreased errors as improvement', () => {
+      const baseline = createBenchmark({ errors: 10 });
+      const target = createBenchmark({ errors: 5 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.diff.errors.absolute).toBe(-5);
+      expect(result.diff.errors.improved).toBe(true);
+    });
+  });
+
+  describe('significant changes', () => {
+    it('should detect significant RPS change (>=5%)', () => {
+      const baseline = createBenchmark({ requestsPerSecond: 1000 });
+      const target = createBenchmark({ requestsPerSecond: 1100 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.significantChanges).toContain(
+        'Requests/sec increased by 10.0%'
+      );
+    });
+
+    it('should not flag insignificant changes (<5%)', () => {
+      const baseline = createBenchmark({ requestsPerSecond: 1000 });
+      const target = createBenchmark({ requestsPerSecond: 1020 });
+
+      const result = compareResults(baseline, target);
+
+      const rpsChange = result.significantChanges.find((c) =>
+        c.includes('Requests/sec')
+      );
+      expect(rpsChange).toBeUndefined();
+    });
+
+    it('should detect error changes regardless of percentage', () => {
+      const baseline = createBenchmark({ errors: 0 });
+      const target = createBenchmark({ errors: 1 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.significantChanges).toContain('Errors increased by 1');
+    });
+  });
+
+  describe('summary determination', () => {
+    it('should return improved when RPS significantly increased', () => {
+      const baseline = createBenchmark({ requestsPerSecond: 1000 });
+      const target = createBenchmark({ requestsPerSecond: 1200 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.summary).toBe('improved');
+    });
+
+    it('should return regressed when RPS significantly decreased', () => {
+      const baseline = createBenchmark({ requestsPerSecond: 1000 });
+      const target = createBenchmark({ requestsPerSecond: 800 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.summary).toBe('regressed');
+    });
+
+    it('should return regressed when errors increased', () => {
+      const baseline = createBenchmark({ errors: 0 });
+      const target = createBenchmark({ errors: 10 });
+
+      const result = compareResults(baseline, target);
+
+      expect(result.summary).toBe('regressed');
+    });
+
+    it('should return neutral when no significant changes', () => {
+      const baseline = createBenchmark({});
+      const target = createBenchmark({});
+
+      const result = compareResults(baseline, target);
+
+      expect(result.summary).toBe('neutral');
+    });
+  });
+});
+
+describe('formatPercentage', () => {
+  it('should format positive percentage with + sign', () => {
+    expect(formatPercentage(10.5)).toBe('+10.50%');
+  });
+
+  it('should format negative percentage without + sign', () => {
+    expect(formatPercentage(-10.5)).toBe('-10.50%');
+  });
+
+  it('should format zero without + sign', () => {
+    expect(formatPercentage(0)).toBe('0.00%');
+  });
+
+  it('should omit sign when showSign is false', () => {
+    expect(formatPercentage(10.5, false)).toBe('10.50%');
+  });
+});
+
+describe('formatLatency', () => {
+  it('should format sub-millisecond latency in microseconds', () => {
+    expect(formatLatency(0.5)).toBe('500μs');
+  });
+
+  it('should format millisecond latency', () => {
+    expect(formatLatency(5.25)).toBe('5.25ms');
+  });
+
+  it('should handle exactly 1ms', () => {
+    expect(formatLatency(1)).toBe('1.00ms');
+  });
+});
+
+describe('formatNumber', () => {
+  it('should format millions with M suffix', () => {
+    expect(formatNumber(1500000)).toBe('1.50M');
+  });
+
+  it('should format thousands with K suffix', () => {
+    expect(formatNumber(1500)).toBe('1.50K');
+  });
+
+  it('should format small numbers without suffix', () => {
+    expect(formatNumber(999)).toBe('999');
+  });
+
+  it('should format exactly 1000 with K suffix', () => {
+    expect(formatNumber(1000)).toBe('1.00K');
+  });
+});
+
+describe('formatBytes', () => {
+  it('should format gigabytes', () => {
+    expect(formatBytes(1073741824)).toBe('1.00 GB');
+  });
+
+  it('should format megabytes', () => {
+    expect(formatBytes(1048576)).toBe('1.00 MB');
+  });
+
+  it('should format kilobytes', () => {
+    expect(formatBytes(1024)).toBe('1.00 KB');
+  });
+
+  it('should format bytes', () => {
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('should handle large GB values', () => {
+    expect(formatBytes(16 * 1073741824)).toBe('16.00 GB');
+  });
+});

--- a/packages/results-store/src/storage.test.ts
+++ b/packages/results-store/src/storage.test.ts
@@ -1,0 +1,520 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { ResultsStorage } from './storage.js';
+import type { BenchmarkResults, StoredBenchmark } from './schema.js';
+
+// Create a temporary directory for testing
+let tempDir: string;
+let storage: ResultsStorage;
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'otel-perf-test-'));
+  storage = new ResultsStorage({ resultsDir: tempDir });
+  await storage.initialize();
+});
+
+afterEach(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+// Helper to create minimal benchmark results
+function createResults(overrides?: Partial<BenchmarkResults>): BenchmarkResults {
+  return {
+    autocannon: {
+      requestsPerSecond: {
+        mean: 1000,
+        stddev: 50,
+        min: 900,
+        max: 1100,
+        p50: 1000,
+        p90: 1050,
+        p99: 1080,
+      },
+      latency: {
+        mean: 10,
+        stddev: 2,
+        min: 5,
+        max: 20,
+        p50: 10,
+        p90: 15,
+        p99: 18,
+      },
+      throughput: {
+        mean: 1000000,
+        stddev: 50000,
+        min: 900000,
+        max: 1100000,
+      },
+      totalRequests: 30000,
+      errors: 0,
+      timeouts: 0,
+    },
+    ...overrides,
+  };
+}
+
+const defaultConfig = {
+  app: 'express',
+  scenario: 'simple-json',
+  mode: 'baseline',
+  connections: 10,
+  duration: 30,
+  pipelining: 1,
+};
+
+describe('ResultsStorage', () => {
+  describe('initialize', () => {
+    it('should create required directories', async () => {
+      const benchmarksDir = path.join(tempDir, 'benchmarks');
+      const comparisonsDir = path.join(tempDir, 'comparisons');
+      const clinicDir = path.join(tempDir, 'clinic-reports');
+
+      await expect(fs.stat(benchmarksDir)).resolves.toBeDefined();
+      await expect(fs.stat(comparisonsDir)).resolves.toBeDefined();
+      await expect(fs.stat(clinicDir)).resolves.toBeDefined();
+    });
+  });
+
+  describe('save', () => {
+    it('should save benchmark and return UUID', async () => {
+      const results = createResults();
+      const id = await storage.save('test-label', results, defaultConfig);
+
+      expect(id).toBeDefined();
+      expect(id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      );
+    });
+
+    it('should save benchmark with git info', async () => {
+      const results = createResults();
+      const gitInfo = {
+        branch: 'feature/test',
+        commit: 'abc123def456',
+        commitMessage: 'Test commit',
+        commitDate: '2024-01-01',
+      };
+
+      const id = await storage.save('test-label', results, defaultConfig, gitInfo);
+      const loaded = await storage.loadById(id);
+
+      expect(loaded).not.toBeNull();
+      expect(loaded!.metadata.git.branch).toBe('feature/test');
+      expect(loaded!.metadata.git.commit).toBe('abc123def456');
+      expect(loaded!.metadata.git.shortCommit).toBe('abc123d');
+    });
+
+    it('should update index after save', async () => {
+      const results = createResults();
+      await storage.save('test-label', results, defaultConfig);
+
+      const index = await storage.list();
+      expect(index).toHaveLength(1);
+      expect(index[0].label).toBe('test-label');
+    });
+  });
+
+  describe('load', () => {
+    it('should load by ID', async () => {
+      const results = createResults();
+      const id = await storage.save('test-label', results, defaultConfig);
+
+      const loaded = await storage.load(id);
+
+      expect(loaded).not.toBeNull();
+      expect(loaded!.metadata.id).toBe(id);
+    });
+
+    it('should load by label', async () => {
+      const results = createResults();
+      await storage.save('test-label', results, defaultConfig);
+
+      const loaded = await storage.load('test-label');
+
+      expect(loaded).not.toBeNull();
+      expect(loaded!.metadata.label).toBe('test-label');
+    });
+
+    it('should return null for non-existent ID', async () => {
+      const loaded = await storage.load('non-existent');
+      expect(loaded).toBeNull();
+    });
+  });
+
+  describe('loadById', () => {
+    it('should load benchmark by specific ID', async () => {
+      const results = createResults();
+      const id = await storage.save('test-label', results, defaultConfig);
+
+      const loaded = await storage.loadById(id);
+
+      expect(loaded).not.toBeNull();
+      expect(loaded!.metadata.id).toBe(id);
+    });
+
+    it('should return null for non-existent ID', async () => {
+      const loaded = await storage.loadById('non-existent-id');
+      expect(loaded).toBeNull();
+    });
+  });
+
+  describe('loadByLabel', () => {
+    it('should load all benchmarks with matching label', async () => {
+      const results = createResults();
+      await storage.save('test-label', results, defaultConfig);
+      await storage.save('test-label', results, {
+        ...defaultConfig,
+        scenario: 'async-io-50ms',
+      });
+      await storage.save('other-label', results, defaultConfig);
+
+      const loaded = await storage.loadByLabel('test-label');
+
+      expect(loaded).toHaveLength(2);
+    });
+
+    it('should return empty array for non-existent label', async () => {
+      const loaded = await storage.loadByLabel('non-existent');
+      expect(loaded).toHaveLength(0);
+    });
+  });
+
+  describe('loadByLabelAndConfig', () => {
+    it('should filter by app', async () => {
+      const results = createResults();
+      await storage.save('test-label', results, { ...defaultConfig, app: 'express' });
+      await storage.save('test-label', results, { ...defaultConfig, app: 'fastify' });
+
+      const loaded = await storage.loadByLabelAndConfig('test-label', 'express');
+
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].metadata.config.app).toBe('express');
+    });
+
+    it('should filter by scenario', async () => {
+      const results = createResults();
+      await storage.save('test-label', results, {
+        ...defaultConfig,
+        scenario: 'simple-json',
+      });
+      await storage.save('test-label', results, {
+        ...defaultConfig,
+        scenario: 'async-io-50ms',
+      });
+
+      const loaded = await storage.loadByLabelAndConfig(
+        'test-label',
+        undefined,
+        'simple-json'
+      );
+
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].metadata.config.scenario).toBe('simple-json');
+    });
+
+    it('should filter by mode', async () => {
+      const results = createResults();
+      await storage.save('test-label', results, { ...defaultConfig, mode: 'baseline' });
+      await storage.save('test-label', results, { ...defaultConfig, mode: 'otel-noop' });
+
+      const loaded = await storage.loadByLabelAndConfig(
+        'test-label',
+        undefined,
+        undefined,
+        'baseline'
+      );
+
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].metadata.config.mode).toBe('baseline');
+    });
+
+    it('should combine multiple filters', async () => {
+      const results = createResults();
+      await storage.save('test-label', results, {
+        app: 'express',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+      await storage.save('test-label', results, {
+        app: 'express',
+        scenario: 'simple-json',
+        mode: 'otel-noop',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+      await storage.save('test-label', results, {
+        app: 'fastify',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+
+      const loaded = await storage.loadByLabelAndConfig(
+        'test-label',
+        'express',
+        'simple-json',
+        'baseline'
+      );
+
+      expect(loaded).toHaveLength(1);
+    });
+  });
+
+  describe('findMatchingPairs', () => {
+    it('should find matching baseline-target pairs', async () => {
+      const results = createResults();
+      await storage.save('baseline', results, {
+        app: 'express',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+      await storage.save('target', results, {
+        app: 'express',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+
+      const pairs = await storage.findMatchingPairs('baseline', 'target');
+
+      expect(pairs).toHaveLength(1);
+      expect(pairs[0].baseline.metadata.label).toBe('baseline');
+      expect(pairs[0].target.metadata.label).toBe('target');
+    });
+
+    it('should not match different configurations', async () => {
+      const results = createResults();
+      await storage.save('baseline', results, {
+        app: 'express',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+      await storage.save('target', results, {
+        app: 'fastify', // Different app
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+
+      const pairs = await storage.findMatchingPairs('baseline', 'target');
+
+      expect(pairs).toHaveLength(0);
+    });
+
+    it('should filter pairs by app', async () => {
+      const results = createResults();
+      await storage.save('baseline', results, {
+        app: 'express',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+      await storage.save('baseline', results, {
+        app: 'fastify',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+      await storage.save('target', results, {
+        app: 'express',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+      await storage.save('target', results, {
+        app: 'fastify',
+        scenario: 'simple-json',
+        mode: 'baseline',
+        connections: 10,
+        duration: 30,
+        pipelining: 1,
+      });
+
+      const pairs = await storage.findMatchingPairs('baseline', 'target', 'express');
+
+      expect(pairs).toHaveLength(1);
+      expect(pairs[0].baseline.metadata.config.app).toBe('express');
+    });
+  });
+
+  describe('list', () => {
+    it('should return all index entries', async () => {
+      const results = createResults();
+      await storage.save('label1', results, defaultConfig);
+      await storage.save('label2', results, defaultConfig);
+
+      const list = await storage.list();
+
+      expect(list).toHaveLength(2);
+    });
+
+    it('should return empty array when no benchmarks', async () => {
+      const list = await storage.list();
+      expect(list).toHaveLength(0);
+    });
+  });
+
+  describe('listByLabel', () => {
+    it('should return entries matching label', async () => {
+      const results = createResults();
+      await storage.save('target-label', results, defaultConfig);
+      await storage.save('target-label', results, {
+        ...defaultConfig,
+        scenario: 'async-io-50ms',
+      });
+      await storage.save('other-label', results, defaultConfig);
+
+      const list = await storage.listByLabel('target-label');
+
+      expect(list).toHaveLength(2);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete by ID', async () => {
+      const results = createResults();
+      const id = await storage.save('test-label', results, defaultConfig);
+
+      const deleted = await storage.delete(id);
+
+      expect(deleted).toBe(true);
+      const loaded = await storage.loadById(id);
+      expect(loaded).toBeNull();
+    });
+
+    it('should delete by label', async () => {
+      const results = createResults();
+      await storage.save('test-label', results, defaultConfig);
+
+      const deleted = await storage.delete('test-label');
+
+      expect(deleted).toBe(true);
+      const list = await storage.list();
+      expect(list).toHaveLength(0);
+    });
+
+    it('should return false for non-existent entry', async () => {
+      const deleted = await storage.delete('non-existent');
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('deleteByLabel', () => {
+    it('should delete all entries with matching label', async () => {
+      const results = createResults();
+      await storage.save('delete-me', results, defaultConfig);
+      await storage.save('delete-me', results, {
+        ...defaultConfig,
+        scenario: 'async-io-50ms',
+      });
+      await storage.save('keep-me', results, defaultConfig);
+
+      const count = await storage.deleteByLabel('delete-me');
+
+      expect(count).toBe(2);
+      const list = await storage.list();
+      expect(list).toHaveLength(1);
+      expect(list[0].label).toBe('keep-me');
+    });
+
+    it('should return 0 when label does not exist', async () => {
+      const count = await storage.deleteByLabel('non-existent');
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('rebuildIndex', () => {
+    it('should rebuild index from benchmark files', async () => {
+      const results = createResults();
+      await storage.save('label1', results, defaultConfig);
+      await storage.save('label2', results, defaultConfig);
+
+      // Clear the index by writing empty array
+      const indexPath = path.join(tempDir, 'index.json');
+      await fs.writeFile(indexPath, '[]');
+
+      // Verify index is empty
+      let list = await storage.list();
+      expect(list).toHaveLength(0);
+
+      // Rebuild
+      const count = await storage.rebuildIndex();
+
+      expect(count).toBe(2);
+      list = await storage.list();
+      expect(list).toHaveLength(2);
+    });
+
+    it('should handle empty benchmarks directory', async () => {
+      const count = await storage.rebuildIndex();
+      expect(count).toBe(0);
+    });
+
+    it('should sort index by timestamp descending', async () => {
+      const results = createResults();
+      await storage.save('older', results, defaultConfig);
+      // Small delay to ensure different timestamps
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await storage.save('newer', results, defaultConfig);
+
+      await storage.rebuildIndex();
+      const list = await storage.list();
+
+      expect(list[0].label).toBe('newer');
+      expect(list[1].label).toBe('older');
+    });
+
+    it('should skip non-JSON files', async () => {
+      const results = createResults();
+      await storage.save('label1', results, defaultConfig);
+
+      // Add a non-JSON file
+      const benchmarksDir = path.join(tempDir, 'benchmarks');
+      await fs.writeFile(path.join(benchmarksDir, 'readme.txt'), 'not json');
+
+      const count = await storage.rebuildIndex();
+
+      expect(count).toBe(1);
+    });
+
+    it('should skip invalid JSON files', async () => {
+      const results = createResults();
+      await storage.save('label1', results, defaultConfig);
+
+      // Add an invalid JSON file
+      const benchmarksDir = path.join(tempDir, 'benchmarks');
+      await fs.writeFile(
+        path.join(benchmarksDir, 'invalid.json'),
+        'not valid json'
+      );
+
+      const count = await storage.rebuildIndex();
+
+      expect(count).toBe(1);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    root: path.resolve(__dirname),
+    include: ['packages/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['packages/*/src/**/*.ts'],
+      exclude: ['packages/*/src/**/*.test.ts', 'packages/*/dist/**'],
+    },
+  },
+});


### PR DESCRIPTION
Configure Vitest as the testing framework and add comprehensive unit tests for:

- results-store/comparison.ts: Tests for calculateDiff behavior (positive/negative
  changes, zero baseline, higher/lower is better metrics), error handling,
  significant changes detection, summary determination, and formatting utilities
  (formatPercentage, formatLatency, formatNumber, formatBytes)

- results-store/storage.ts: Tests for ResultsStorage class including save/load
  operations, index management, findMatchingPairs, delete operations, and
  rebuildIndex functionality with edge cases

- cli/utils.ts: Tests for parseArgs (flags, boolean flags, real-world scenarios),
  getDefaultOtelPath, formatDuration (ms/s/minutes), and expandPath

All 87 tests pass. Updated README.md and CLAUDE.md with testing documentation.